### PR TITLE
KEYCLOAK-14218 Fixes missing localization of groups tree root node name

### DIFF
--- a/themes/src/main/resources/theme/base/admin/resources/js/authz/authz-controller.js
+++ b/themes/src/main/resources/theme/base/admin/resources/js/authz/authz-controller.js
@@ -1772,7 +1772,7 @@ module.controller('ResourceServerPolicyRoleDetailCtrl', function($scope, $route,
     }
 });
 
-module.controller('ResourceServerPolicyGroupDetailCtrl', function($scope, $route, realm, client, Client, Groups, Group, PolicyController, Notifications) {
+module.controller('ResourceServerPolicyGroupDetailCtrl', function($scope, $route, realm, client, Client, Groups, Group, PolicyController, Notifications, $translate) {
     PolicyController.onInit({
         getPolicyType : function() {
             return "group";
@@ -1784,7 +1784,7 @@ module.controller('ResourceServerPolicyGroupDetailCtrl', function($scope, $route
             Groups.query({realm: $route.current.params.realm}, function(groups) {
                 $scope.groups = groups;
                 $scope.groupList = [
-                    {"id" : "realm", "name": "Groups",
+                    {"id" : "realm", "name": $translate.instant('groups'),
                                 "subGroups" : groups}
                 ];
             });

--- a/themes/src/main/resources/theme/base/admin/resources/js/controllers/groups.js
+++ b/themes/src/main/resources/theme/base/admin/resources/js/controllers/groups.js
@@ -1,9 +1,9 @@
-module.controller('GroupListCtrl', function($scope, $route, $q, realm, Groups, GroupsCount, Group, GroupChildren, Notifications, $location, Dialog, ComponentUtils) {
+module.controller('GroupListCtrl', function($scope, $route, $q, realm, Groups, GroupsCount, Group, GroupChildren, Notifications, $location, Dialog, ComponentUtils, $translate) {
     $scope.realm = realm;
     $scope.groupList = [
         {
             "id" : "realm",
-            "name": "Groups",
+            "name": $translate.instant('groups'),
             "subGroups" : []
         }
     ];
@@ -46,7 +46,7 @@ module.controller('GroupListCtrl', function($scope, $route, $q, realm, Groups, G
             $scope.groupList = [
                 {
                     "id" : "realm",
-                    "name": "Groups",
+                    "name": $translate.instant('groups'),
                     "subGroups": ComponentUtils.sortGroups('name', groups)
                 }
             ];


### PR DESCRIPTION
* Injecting `$translate` into controllers and using translation of existing `groups` message for the groups tree root node name.